### PR TITLE
Remove `multipleResolves` event listener

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ const { error } = require("./logger.js");
 process.on("unhandledRejection", (r, p) => error(r, p));
 process.on("uncaughtException", (e, o) => error(e, o));
 process.on("uncaughtExceptionMonitor", (e, o) => error(e, o));
-process.on("multipleResolves", (t, p, v) => error(t, v, p));
 
 require("./db.js");
 const { Client } = require("discord.js");


### PR DESCRIPTION
Remove `multipleResolves` event listener as it's deprecated
It has been used here to log when a promise is resolved/rejected more than once

nodejs/node#41872